### PR TITLE
Fs changes

### DIFF
--- a/essence.css
+++ b/essence.css
@@ -41,7 +41,7 @@
 }
 
 .vs .monaco-workbench>.part.editor>.content>.one-editor-silo>.container>.title .tabs-container>.tab:not(.active) {
-    background: #fff;
+    background: #eee;
 }
 
 .monaco-workbench>.part.editor>.content>.one-editor-silo>.container>.title:not(.tabs) {
@@ -115,7 +115,7 @@
 }*/
 
 .monaco-workbench .monaco-editor.mac .margin-view-overlays .line-numbers {
-    opacity: 0.1;
+    opacity: 0.2;
     transition: opacity 0.09s ease-in-out;
     will-change: opacity;
 }

--- a/essence.css
+++ b/essence.css
@@ -241,6 +241,10 @@
     background: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='13' height='13' viewBox='-295.5 390.5 13 13'%3E%3Cpath fill='%23ccc' d='M-289 390.5c-3.6 0-6.5 2.9-6.5 6.5s2.9 6.5 6.5 6.5 6.5-2.9 6.5-6.5-2.9-6.5-6.5-6.5zm.9 11.1h-1.9v-6.5h1.9v6.5zm0-7.4h-1.9v-1.9h1.9v1.9z'/%3E%3C/svg%3E") 6px 6px no-repeat;
 }
 
+.monaco-editor .scroll-decoration {
+    box-shadow: none;
+}
+
 .quick-open-widget,
 .monaco-editor .defineKeybindingWidget,
 .monaco-editor .accessibilityHelpWidget {


### PR DESCRIPTION
In case you’re interested in a couple of changes I’ve applied:

- gave the inactive a grey background so it’s easier to tell which tab is active
- increased opacity of line numbers slightly
- disabled the shadow at the top of the editor that appears when the content is scrolled down a bit

<img width="609" alt="screen shot 2016-12-22 at 18 23 07" src="https://cloud.githubusercontent.com/assets/65520/21434284/f06a0cec-c873-11e6-9eb9-e9a222381fae.png">
